### PR TITLE
Fix: Memory leaks on LiveStreamVM

### DIFF
--- a/SampleCode-V5/android-sdk-v5-sample/src/main/java/dji/sampleV5/aircraft/models/LiveStreamVM.kt
+++ b/SampleCode-V5/android-sdk-v5-sample/src/main/java/dji/sampleV5/aircraft/models/LiveStreamVM.kt
@@ -15,6 +15,7 @@ import dji.v5.manager.datacenter.livestream.settings.RtspSettings
 import dji.v5.manager.interfaces.ICameraStreamManager
 import dji.v5.utils.common.ContextUtil
 import dji.v5.utils.common.DjiSharedPreferencesManager
+import java.lang.ref.WeakReference
 
 /**
  * ClassName : LiveStreamVM
@@ -69,10 +70,11 @@ class LiveStreamVM : DJIViewModel() {
     }
 
     fun startStream(callback: CommonCallbacks.CompletionCallback?) {
+        val weakReference = WeakReference(this)
         streamManager.startStream(object : CommonCallbacks.CompletionCallback {
             override fun onSuccess() {
                 CallbackUtils.onSuccess(callback)
-                reset();
+                weakReference.get()?.reset()
             }
 
             override fun onFailure(error: IDJIError) {
@@ -83,10 +85,11 @@ class LiveStreamVM : DJIViewModel() {
     }
 
     fun stopStream(callback: CommonCallbacks.CompletionCallback?) {
+        val weakReference = WeakReference(this)
         streamManager.stopStream(object : CommonCallbacks.CompletionCallback {
             override fun onSuccess() {
                 CallbackUtils.onSuccess(callback)
-                reset();
+                weakReference.get()?.reset()
             }
 
             override fun onFailure(error: IDJIError) {


### PR DESCRIPTION
Thank you for providing v5.8.0. I tried it on my side and found a memory leak on LiveStreamVM.
Please take a look and let me know if you need further information.

Cause: streamManager keeps retaining reset() after LiveFragment destroyed

![memory-leaks-on-live-stream-vm](https://github.com/dji-sdk/Mobile-SDK-Android-V5/assets/54883/f36c7b01-a10b-4bf2-b6d0-1387fc28e167)
