### PR TITLE
Update applicationId in defaultConfig

### DIFF
--- a/SampleCode-V5/android-sdk-v5-sample/build.gradle
+++ b/SampleCode-V5/android-sdk-v5-sample/build.gradle
@@ -6,7 +6,7 @@ android {
     compileSdkVersion Integer.parseInt(project.ANDROID_COMPILE_SDK_VERSION)
 
     defaultConfig {
-        applicationId "com.dji.sampleV5.aircraft"
+        applicationId "dji.sampleV5.aircraft"
         minSdkVersion Integer.parseInt(project.ANDROID_MIN_SDK_VERSION)
         targetSdkVersion Integer.parseInt(project.ANDROID_TARGET_SDK_VERSION)
         versionCode 1


### PR DESCRIPTION
I ran into registration failure when running the sample app and found that this applicationId did not match the registered package name. After removing `com.` and making it identical as registered on developer portal, the app registers successfully.